### PR TITLE
Add adjustable viewer scale

### DIFF
--- a/src/components/SidePanel.vue
+++ b/src/components/SidePanel.vue
@@ -6,6 +6,7 @@
     <BackgroundControls />
     <MultiSkinSelector />
     <MultiTrackSelector />
+    <ScaleControl />
     <PlaybackControls />
     <GitHubLink />
   </div>
@@ -18,6 +19,7 @@ import BackgroundControls from './controls/BackgroundControls.vue'
 import PlaybackControls from './controls/PlaybackControls.vue'
 import MultiSkinSelector from './controls/MultiSkinSelector.vue'
 import MultiTrackSelector from './controls/MultiTrackSelector.vue'
+import ScaleControl from './controls/ScaleControl.vue'
 import LanguageSelector from './controls/LanguageSelector.vue'
 import GitHubLink from './controls/GitHubLink.vue'
 </script>

--- a/src/components/controls/ScaleControl.vue
+++ b/src/components/controls/ScaleControl.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="scale-control" v-if="phaserStore.isAnimationLoaded">
+    <label for="scaleSlider">
+      {{ t('scale.title') }} <span id="scaleValue">{{ scaleFactor.toFixed(1) }}</span>
+    </label>
+    <input
+      type="range"
+      id="scaleSlider"
+      class="control-slider"
+      min="0.1"
+      max="1.5"
+      step="0.1"
+      v-model.number="scaleFactor"
+    />
+    <button @click="resetScale" class="control-button">{{ t('scale.reset') }}</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { phaserStore } from '@/store/phaserStore.js'
+
+const { t } = useI18n()
+
+const scaleFactor = ref(phaserStore.scaleFactor)
+
+watch(scaleFactor, (newVal) => {
+  phaserStore.setScaleFactor(newVal)
+  const scene = phaserStore.gameInstance?.scene.getScene('GameScene')
+  if (scene && phaserStore.spineObject) {
+    scene.fitAndCenterSpineObject(phaserStore.spineObject)
+  }
+})
+
+const resetScale = () => {
+  scaleFactor.value = 0.9
+}
+</script>
+
+<style lang="postcss" scoped>
+.scale-control {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  & > label {
+    font-weight: 600;
+    font-size: 1.1em;
+    color: var(--color-white);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.control-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  background: var(--color-gray);
+  border-radius: 5px;
+  outline: none;
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    background: var(--color-red-light);
+    border-radius: 50%;
+  }
+
+  &::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    background: var(--color-red-light);
+    border-radius: 50%;
+    border: none;
+  }
+}
+
+#scaleValue {
+  font-weight: 600;
+  color: var(--color-red-light);
+  background-color: var(--color-section);
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-size: 0.9em;
+}
+</style>

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -36,6 +36,10 @@
     "timescale": "Timescale",
     "reset": "Reset Speed"
   },
+  "scale": {
+    "title": "Viewer Scale",
+    "reset": "Reset Scale"
+  },
   "version": {
     "title": "Spine Runtime Version",
     "spine41": "Spine 4.1",

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -36,6 +36,10 @@
     "timescale": "時間倍率",
     "reset": "重設速度"
   },
+  "scale": {
+    "title": "縮放調整",
+    "reset": "重設縮放"
+  },
   "version": {
     "title": "Spine 執行時版本",
     "spine41": "Spine 4.1",

--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -79,7 +79,7 @@ export class GameScene extends Phaser.Scene {
       console.warn('⚠️ Missing PNG files:', missing.join(', '))
       alert(
         `These texture pages are referenced in the atlas but were not selected:\n` +
-        missing.join('\n'),
+          missing.join('\n'),
       )
     }
 
@@ -132,7 +132,8 @@ export class GameScene extends Phaser.Scene {
 
     if (bounds.size.x > 0 && bounds.size.y > 0) {
       const scale =
-        Math.min(this.scale.width / bounds.size.x, this.scale.height / bounds.size.y) * 0.9
+        Math.min(this.scale.width / bounds.size.x, this.scale.height / bounds.size.y) *
+        phaserStore.scaleFactor
       spineObj.setScale(scale)
     }
 

--- a/src/store/phaserStore.js
+++ b/src/store/phaserStore.js
@@ -6,6 +6,7 @@ export const phaserStore = reactive({
   skins: [],
   animations: [],
   isAnimationLoaded: false,
+  scaleFactor: 0.9,
 
   setGameInstance(game) {
     this.gameInstance = game
@@ -22,6 +23,10 @@ export const phaserStore = reactive({
 
   setAnimations(animationNames) {
     this.animations = animationNames
+  },
+
+  setScaleFactor(factor) {
+    this.scaleFactor = factor
   },
 
   cleanup() {


### PR DESCRIPTION
## Summary
- add a scaleFactor option in the Vue store
- allow user to adjust the viewer scale with a new control
- center & scale spine objects using the configurable factor
- localize strings for the new control

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68678d349a0c83339ee8b883d0e2aa01