### PR TITLE
fix: atlas page name regex in GameScene

### DIFF
--- a/src/phaser/GameScene.js
+++ b/src/phaser/GameScene.js
@@ -51,7 +51,7 @@ export class GameScene extends Phaser.Scene {
 
     const skelKey = `spine_${Date.now()}`
     const atlasKey = skelKey
-    const pageRegex = /^\s*(\S+\.(?:png|pma\.png))/gim
+    const pageRegex = /^\s*([^\r\n]+?\.(?:png|pma\.png))\s*$/gim
 
     const pageNames = [...atlasTxt.matchAll(pageRegex)]
       .map((m) => m[1])


### PR DESCRIPTION
## Pull Request – **Allow spaces in atlas page names**

> **Branch:** `fix/allow-spaces-in-atlas-page-names`
> **Closes:** #7 

---

### Summary

This PR fixes a bug where texture pages whose filenames contain spaces (e.g. `女主-後面插2 -拆分1920X1080.png`) were silently ignored during Spine asset loading.
The root cause was the overly-strict regex used to parse page names from the `.atlas` file. Replacing it with a relaxed pattern ensures **all** valid filenames are captured.

---

### What’s Changed

```diff
// src/phaser/GameScene.js

- const pageRegex = /^\s*(\S+\.(?:png|pma\.png))/gim
+ // allow spaces inside page names, stop at end-of-line
+ const pageRegex = /^\s*([^\r\n]+?\.(?:png|pma\.png))\s*$/gim
```

No other files were modified.

---

### How to Test

1. **Start dev server**

   ```bash
   npm dev
   ```

2. **Upload a Spine pack** that includes

   * `*.json` skeleton
   * `*.atlas` file
   * one or more PNGs whose filenames contain spaces

3. **Expected results**

   * Spine object renders correctly on screen
   * Console shows no `loaderror` events
   * “Missing PNG files” alert **does not** appear

---

### Checklist

* [x] Code compiles & lints pass
* [x] Manual test with filenames containing spaces
* [x] No regression with filenames **without** spaces
