### PR TITLE
Add drag-and-drop upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A web-based viewer for [Spine](http://esotericsoftware.com/) animations, built w
 
 ## Features
 -   **Load Custom Animations**: Upload your `.json`, `.atlas`, and `.png` files to view your Spine animations.
+-   **Drag and Drop Support**: Drop all required files onto the uploader in one action.
 -   **Runtime Version Switching**: Easily switch between different Spine runtime versions (e.g., 4.1, 4.2) and reload the application.
 -   **Multi-Track Animations**: Play multiple animations simultaneously on different tracks.
 -   **Playback Control**: Pause, play, and adjust the animation speed (timescale).
@@ -48,7 +49,7 @@ Lints the source code using ESLint.
                                                                                     
 ## How to Use the Viewer
 1.  (Optional) Select your desired Spine runtime version from the dropdown and click "Reload with Version".
-2.  Use the "Upload Animation Files" section to select your Spine `.json`, `.atlas`, and ixmage (`.png`) files.
+2.  Use the "Upload Animation Files" section to select your Spine `.json`, `.atlas`, and image (`.png`) files, or simply drag them all onto the uploader.
 3.  Click the "Load Animation" button.
 4.  Once loaded, use the controls on the side panel to interact with your animation (change skins, play different animations, adjust speed, etc.).
 

--- a/src/components/controls/FileUploader.vue
+++ b/src/components/controls/FileUploader.vue
@@ -2,6 +2,16 @@
   <div class="upload-section">
     <label>{{ t('uploader.title') }}</label>
 
+    <div
+      class="drop-area"
+      :class="{ dragging: isDragging }"
+      @dragover.prevent="isDragging = true"
+      @dragleave="isDragging = false"
+      @drop.prevent="handleDrop"
+    >
+      {{ t('uploader.drag_hint') }}
+    </div>
+
     <label for="json-upload" class="control-button file-label">
       <span class="file-button-text">{{ t('uploader.select_json') }}</span>
       <span class="file-name-display">{{ jsonFileName }}</span>
@@ -58,6 +68,8 @@ const files = ref({
   pngFiles: null,
 })
 
+const isDragging = ref(false)
+
 const jsonFileName = computed(() => files.value.jsonFile?.name || '')
 const atlasFileName = computed(() => files.value.atlasFile?.name || '')
 const pngFileName = computed(() => {
@@ -73,6 +85,24 @@ const handleFileChange = (event, type) => {
   if (type === 'json') files.value.jsonFile = fileList[0]
   if (type === 'atlas') files.value.atlasFile = fileList[0]
   if (type === 'png') files.value.pngFiles = Array.from(fileList)
+}
+
+const handleDrop = (event) => {
+  isDragging.value = false
+  const dropped = Array.from(event.dataTransfer.files)
+  if (!dropped.length) return
+
+  for (const file of dropped) {
+    const name = file.name.toLowerCase()
+    if (name.endsWith('.json') && !files.value.jsonFile) {
+      files.value.jsonFile = file
+    } else if ((name.endsWith('.atlas') || name.endsWith('.txt')) && !files.value.atlasFile) {
+      files.value.atlasFile = file
+    } else if (name.endsWith('.png') || name.endsWith('.pma') || name.endsWith('.pma.png')) {
+      if (!files.value.pngFiles) files.value.pngFiles = []
+      files.value.pngFiles.push(file)
+    }
+  }
 }
 
 const loadAnimation = () => {
@@ -130,5 +160,22 @@ const loadAnimation = () => {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
+}
+
+.drop-area {
+  padding: 20px;
+  text-align: center;
+  border: 2px dashed var(--color-gray-dark);
+  background: var(--color-section);
+  border-radius: 8px;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+  cursor: pointer;
+}
+
+.drop-area.dragging {
+  background: var(--color-gray-dark);
+  border-color: var(--color-red);
 }
 </style>

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -10,6 +10,7 @@
     "select_json": "1. Select .JSON File",
     "select_atlas": "2. Select .ATLAS File",
     "select_png": "3. Select .PNG Image(s)",
+    "drag_hint": "Or drag all files here",
     "load": "Load Animation",
     "missing_files": "Please select all required files (.json, .atlas, and at least one .png)."
   },

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -10,6 +10,7 @@
     "select_json": "1. 選擇 .JSON 檔案",
     "select_atlas": "2. 選擇 .ATLAS 檔案",
     "select_png": "3. 選擇 .PNG 圖片",
+    "drag_hint": "或將所有檔案拖曳至此",
     "load": "載入動畫",
     "missing_files": "請選擇所有必要的檔案 (.json、.atlas 及至少一個 .png)。"
   },


### PR DESCRIPTION
## Summary
- allow dragging Spine json, atlas, and png files in one drop
- document the drag-and-drop workflow in README
- add translations for drag hint

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_688c85ac1dc08333aa6bf47b4a84e6a3