### PR TITLE
feat: auto apply skins and tracks

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -90,6 +90,11 @@ body {
   color: var(--color-white);
 }
 
+.control-button.clear-button {
+  background: linear-gradient(145deg, var(--color-gray), var(--color-gray-dark));
+  color: var(--color-white);
+}
+
 /* --- (NEW) COMMON POPUP STYLES --- */
 .multi-track-popup,
 .multi-skin-popup {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -85,11 +85,6 @@ body {
   color: var(--color-black);
 }
 
-.control-button.apply-button {
-  background: linear-gradient(145deg, var(--color-green-light), var(--color-green));
-  color: var(--color-black);
-}
-
 .control-button.close-button {
   background: linear-gradient(145deg, var(--color-red-light), var(--color-red));
   color: var(--color-white);

--- a/src/components/modals/MultiSkinModal.vue
+++ b/src/components/modals/MultiSkinModal.vue
@@ -17,6 +17,9 @@
     </div>
 
     <div class="popup-button-container">
+      <button @click="clearSkins" class="control-button clear-button">
+        {{ t('modal.clear_all') }}
+      </button>
       <button @click="$emit('close')" class="control-button close-button">
         {{ t('modal.close') }}
       </button>
@@ -60,6 +63,10 @@ const applySkins = () => {
   }
   skeleton.setSlotsToSetupPose()
   phaserStore.spineObject.scene.fitAndCenterSpineObject(phaserStore.spineObject)
+}
+
+const clearSkins = () => {
+  selectedSkins.value = []
 }
 
 watch(selectedSkins, applySkins, { deep: true })

--- a/src/components/modals/MultiSkinModal.vue
+++ b/src/components/modals/MultiSkinModal.vue
@@ -17,9 +17,6 @@
     </div>
 
     <div class="popup-button-container">
-      <button @click="applySkins" class="control-button apply-button">
-        {{ t('modal.apply') }}
-      </button>
       <button @click="$emit('close')" class="control-button close-button">
         {{ t('modal.close') }}
       </button>
@@ -28,12 +25,12 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { phaserStore } from '@/store/phaserStore.js'
 import { useDraggable } from '@/composables/useDraggable.js'
 const { t } = useI18n()
-const emit = defineEmits(['close'])
+defineEmits(['close'])
 
 const popupRef = ref(null)
 const handleRef = ref(null)
@@ -63,8 +60,9 @@ const applySkins = () => {
   }
   skeleton.setSlotsToSetupPose()
   phaserStore.spineObject.scene.fitAndCenterSpineObject(phaserStore.spineObject)
-  emit('close')
 }
+
+watch(selectedSkins, applySkins, { deep: true })
 </script>
 
 <style lang="postcss" scoped>

--- a/src/components/modals/MultiTrackModal.vue
+++ b/src/components/modals/MultiTrackModal.vue
@@ -21,9 +21,6 @@
     </div>
 
     <div class="popup-button-container">
-      <button @click="applyTracks" class="control-button apply-button">
-        {{ t('modal.apply') }}
-      </button>
       <button @click="$emit('close')" class="control-button close-button">
         {{ t('modal.close') }}
       </button>
@@ -32,11 +29,11 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { phaserStore } from '@/store/phaserStore.js'
 import { useDraggable } from '@/composables/useDraggable.js'
-const emit = defineEmits(['close'])
+defineEmits(['close'])
 
 const { t } = useI18n()
 
@@ -64,8 +61,9 @@ const applyTracks = () => {
     }
   }
   phaserStore.spineObject.scene.fitAndCenterSpineObject(phaserStore.spineObject)
-  emit('close')
 }
+
+watch(trackSelections, applyTracks, { deep: true })
 </script>
 
 <style lang="postcss" scoped>

--- a/src/components/modals/MultiTrackModal.vue
+++ b/src/components/modals/MultiTrackModal.vue
@@ -21,6 +21,9 @@
     </div>
 
     <div class="popup-button-container">
+      <button @click="clearTracks" class="control-button clear-button">
+        {{ t('modal.clear_all') }}
+      </button>
       <button @click="$emit('close')" class="control-button close-button">
         {{ t('modal.close') }}
       </button>
@@ -61,6 +64,10 @@ const applyTracks = () => {
     }
   }
   phaserStore.spineObject.scene.fitAndCenterSpineObject(phaserStore.spineObject)
+}
+
+const clearTracks = () => {
+  trackSelections.value = Array(maxTracks).fill('')
 }
 
 watch(trackSelections, applyTracks, { deep: true })

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -27,7 +27,8 @@
   },
   "modal": {
     "select_skins": "Select Skins",
-    "close": "Close"
+    "close": "Close",
+    "clear_all": "Clear All"
   },
   "playback": {
     "title": "Playback Controls",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -27,7 +27,6 @@
   },
   "modal": {
     "select_skins": "Select Skins",
-    "apply": "Apply",
     "close": "Close"
   },
   "playback": {

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -27,7 +27,6 @@
   },
   "modal": {
     "select_skins": "選擇皮膚",
-    "apply": "套用",
     "close": "關閉"
   },
   "playback": {

--- a/src/locales/zh-tw.json
+++ b/src/locales/zh-tw.json
@@ -27,7 +27,8 @@
   },
   "modal": {
     "select_skins": "選擇皮膚",
-    "close": "關閉"
+    "close": "關閉",
+    "clear_all": "清除所有"
   },
   "playback": {
     "title": "播放控制",


### PR DESCRIPTION
## Summary
- remove Apply buttons for skins and tracks
- automatically apply selected skins/tracks when changed
- drop unused translation entries and styles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688cd900feb88333bb9e725204c9bf59